### PR TITLE
Reducing RAM usage by ESP8266

### DIFF
--- a/src/u8g2_fonts.h
+++ b/src/u8g2_fonts.h
@@ -58,6 +58,13 @@
 #  define U8X8_PROGMEM PROGMEM
 #endif
 
+#if defined(__GNUC__) && defined(ESP8266)
+#  include "c_types.h"
+#  define U8X8_FONT_SECTION(name) ICACHE_FLASH_ATTR
+#  define u8x8_pgm_read(adr) pgm_read_byte_near(adr)
+#  define U8X8_PROGMEM PROGMEM
+#endif
+
 #ifndef U8X8_FONT_SECTION
 #  define U8X8_FONT_SECTION(name) 
 #endif


### PR DESCRIPTION
This fix optimizes the usage of memory. Fonts are no longer buffered in RAM, instead they are being read directly from Flash.
Based on https://github.com/olikraus/u8g2/issues/159
Tested and verified on ESP8266 NodeMCU ESP12F